### PR TITLE
Simplify NMSSH execute error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
-# test
-testing
-change1
+# ShutdownCommander
+
+一个可安装到 iPhone 的 iOS App，通过 SSH 连接到家中局域网台式机并执行关机命令。关机参数可在 App 内配置。
+
+## 功能
+
+- 保存主机地址、端口、用户名与密码。
+- 可自定义关机命令（例如 `sudo /sbin/shutdown -h now`）。
+- 一键发送关机指令并显示执行结果。
+
+## 构建方式
+
+1. 使用 Xcode 15+ 创建一个新的 iOS App 项目（SwiftUI）。
+2. 将 `ShutdownCommander` 目录中的 Swift 文件复制到项目中。
+3. 在 Xcode 中添加 Swift Package 依赖：
+   - Package URL: `https://github.com/NMSSH/NMSSH`
+   - 版本：`2.2.7` 或最新稳定版。
+4. 选择你的真机并运行，即可安装到手机。
+
+## 使用说明
+
+1. 确保 iPhone 与台式机在同一局域网中。
+2. 在 App 内输入台式机的 IP、端口、用户名与密码。
+3. 根据需要修改关机命令（可以设置为 `sudo /sbin/shutdown -h now` 或其他参数）。
+4. 点击「立即关机」发送指令。
+
+## 目标电脑建议配置
+
+- 确保 SSH 服务开启。
+- 若使用 `sudo`，建议配置无密码 sudo（仅限关机命令）以避免交互阻塞。
+
+```bash
+sudo visudo
+# 添加类似行：
+# youruser ALL=(ALL) NOPASSWD: /sbin/shutdown
+```

--- a/ShutdownCommander/ContentView.swift
+++ b/ShutdownCommander/ContentView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct ContentView: View {
+    @AppStorage("ssh.host") private var host = ""
+    @AppStorage("ssh.port") private var port = 22
+    @AppStorage("ssh.username") private var username = ""
+    @AppStorage("ssh.password") private var password = ""
+    @AppStorage("ssh.shutdownCommand") private var shutdownCommand = "sudo /sbin/shutdown -h now"
+
+    @State private var statusMessage = ""
+    @State private var isRunning = false
+
+    private let sshClient = SSHClient()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("连接信息") {
+                    TextField("主机地址 (例如 192.168.1.10)", text: $host)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    Stepper(value: $port, in: 1...65535) {
+                        HStack {
+                            Text("端口")
+                            Spacer()
+                            Text("\(port)")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    TextField("用户名", text: $username)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    SecureField("密码", text: $password)
+                }
+
+                Section("关机命令") {
+                    TextEditor(text: $shutdownCommand)
+                        .frame(minHeight: 80)
+                        .font(.body)
+                    Text("需要确保目标机器允许该命令执行，可考虑配置 sudo 无密码执行。")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+
+                Section {
+                    Button {
+                        runShutdown()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isRunning {
+                                ProgressView()
+                            } else {
+                                Text("立即关机")
+                                    .fontWeight(.semibold)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(isRunning || host.isEmpty || username.isEmpty || password.isEmpty)
+                }
+
+                if !statusMessage.isEmpty {
+                    Section("状态") {
+                        Text(statusMessage)
+                            .font(.footnote)
+                    }
+                }
+            }
+            .navigationTitle("局域网关机")
+        }
+    }
+
+    private func runShutdown() {
+        isRunning = true
+        statusMessage = "正在发送关机指令..."
+
+        let config = SSHConfig(
+            host: host,
+            port: port,
+            username: username,
+            password: password,
+            shutdownCommand: shutdownCommand
+        )
+
+        sshClient.runShutdown(config: config) { result in
+            isRunning = false
+            switch result {
+            case let .success(response):
+                statusMessage = response.isEmpty ? "命令已发送。" : response
+            case let .failure(error):
+                statusMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/ShutdownCommander/Models/SSHConfig.swift
+++ b/ShutdownCommander/Models/SSHConfig.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct SSHConfig: Equatable {
+    var host: String
+    var port: Int
+    var username: String
+    var password: String
+    var shutdownCommand: String
+
+    static let empty = SSHConfig(
+        host: "",
+        port: 22,
+        username: "",
+        password: "",
+        shutdownCommand: "sudo /sbin/shutdown -h now"
+    )
+}

--- a/ShutdownCommander/Services/SSHClient.swift
+++ b/ShutdownCommander/Services/SSHClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+import NMSSH
+
+final class SSHClient {
+    func runShutdown(config: SSHConfig, completion: @escaping (Result<String, Error>) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let session = NMSSHSession(host: config.host, port: config.port, andUsername: config.username)
+            session.connect()
+
+            guard session.isConnected else {
+                DispatchQueue.main.async {
+                    completion(.failure(SSHClientError.connectionFailed))
+                }
+                return
+            }
+
+            session.authenticate(byPassword: config.password)
+
+            guard session.isAuthorized else {
+                session.disconnect()
+                DispatchQueue.main.async {
+                    completion(.failure(SSHClientError.authenticationFailed))
+                }
+                return
+            }
+
+            var executionError: NSError?
+            let response = session.channel.execute(config.shutdownCommand, error: &executionError)
+            session.disconnect()
+
+            DispatchQueue.main.async {
+                if let executionError = executionError {
+                    completion(.failure(SSHClientError.remoteError(executionError.localizedDescription)))
+                } else {
+                    completion(.success(response ?? ""))
+                }
+            }
+        }
+    }
+}
+
+enum SSHClientError: LocalizedError {
+    case connectionFailed
+    case authenticationFailed
+    case remoteError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionFailed:
+            return "无法连接到主机，请检查地址和端口。"
+        case .authenticationFailed:
+            return "认证失败，请检查用户名和密码。"
+        case let .remoteError(message):
+            return "命令执行失败：\(message)"
+        }
+    }
+}

--- a/ShutdownCommander/ShutdownCommanderApp.swift
+++ b/ShutdownCommander/ShutdownCommanderApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ShutdownCommanderApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix a missing `error` argument usage and make remote command failure reporting rely on NMSSH's `execute(..., error:)` NSError pointer instead of falling back to `session.channel.lastError`.

### Description
- Update `ShutdownCommander/Services/SSHClient.swift` to call `session.channel.execute(config.shutdownCommand, error: &executionError)`, check `executionError` and return `SSHClientError.remoteError(executionError.localizedDescription)` when present, while keeping `session.disconnect()` and dispatching completion on the main queue.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5a4461d8832c8959ecb4db1497d0)