### PR TITLE
Guard NMSSH usage with canImport and provide fallback error

### DIFF
--- a/ShutdownCommander/Services/SSHClient.swift
+++ b/ShutdownCommander/Services/SSHClient.swift
@@ -1,9 +1,13 @@
 import Foundation
+
+#if canImport(NMSSH)
 import NMSSH
+#endif
 
 final class SSHClient {
     func runShutdown(config: SSHConfig, completion: @escaping (Result<String, Error>) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
+#if canImport(NMSSH)
             let session = NMSSHSession(host: config.host, port: config.port, andUsername: config.username)
             session.connect()
 
@@ -36,6 +40,11 @@ final class SSHClient {
                     completion(.success(response ?? ""))
                 }
             }
+#else
+            DispatchQueue.main.async {
+                completion(.failure(SSHClientError.missingDependency))
+            }
+#endif
         }
     }
 }
@@ -44,6 +53,7 @@ enum SSHClientError: LocalizedError {
     case connectionFailed
     case authenticationFailed
     case remoteError(String)
+    case missingDependency
 
     var errorDescription: String? {
         switch self {
@@ -53,6 +63,8 @@ enum SSHClientError: LocalizedError {
             return "认证失败，请检查用户名和密码。"
         case let .remoteError(message):
             return "命令执行失败：\(message)"
+        case .missingDependency:
+            return "缺少 NMSSH 依赖，请在项目中添加 NMSSH 以启用 SSH 功能。"
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent build failures on targets that don't have the `NMSSH` dependency and provide a clear runtime error if SSH functionality is requested but the dependency is missing.
- Surface a localized error message so the app can fail gracefully instead of crashing when `NMSSH` is unavailable.

### Description
- Wrap the `import NMSSH` with `#if canImport(NMSSH)` to make the dependency optional at compile time.
- Guard the `NMSSHSession` usage inside `runShutdown` with the same `#if canImport(NMSSH)` conditional so code only uses `NMSSH` when available.
- Add a new `SSHClientError.missingDependency` case and a localized description `"缺少 NMSSH 依赖，请在项目中添加 NMSSH 以启用 SSH 功能。"` and return that error when `NMSSH` is not available.
- Ensure `completion` is invoked on the main queue with the `missingDependency` error when the dependency is absent.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d3b35ca0832c9ea79335628e47f3)