### PR TITLE
Fix SSH error handling

### DIFF
--- a/ShutdownCommander/Services/SSHClient.swift
+++ b/ShutdownCommander/Services/SSHClient.swift
@@ -26,7 +26,7 @@ final class SSHClient {
 
             var executionError: NSError?
             let response = session.channel.execute(config.shutdownCommand, error: &executionError)
-            let errorMessage = executionError?.localizedDescription ?? session.channel.lastError
+            let errorMessage = executionError?.localizedDescription
             session.disconnect()
 
             DispatchQueue.main.async {


### PR DESCRIPTION
### Motivation
- Remove reference to non-existent `NMSSHChannel.lastError` and rely on `executionError?.localizedDescription` for remote error reporting to prevent compile-time failures.

### Description
- Replace `session.channel.lastError` fallback with `executionError?.localizedDescription` in `SSHClient.runShutdown` to avoid using an unavailable NMSSH API.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d5a44ce8832ca72db51d16db3135)